### PR TITLE
Fixed broken tests in rack-session-redis master

### DIFF
--- a/lib/rack/session/redis.rb
+++ b/lib/rack/session/redis.rb
@@ -108,6 +108,10 @@ module Rack
         @mutex.unlock if env['rack.multithread']
       end
 
+      def destroy_session(env, session_id, options)
+        set_session(env, session_id, nil, {:drop => true}.merge(options))
+      end
+
       private
 
       def merge_sessions sid, old, new, cur=nil

--- a/test/spec_session_redis.rb
+++ b/test/spec_session_redis.rb
@@ -69,7 +69,6 @@ describe Rack::Session::Redis do
     app.redis.dbsize.should.equal 1
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
-    res1["Set-Cookie"][session_match].should.equal session
     res1.body.should.equal '{"counter"=>2}'
     app.redis.dbsize.should.equal 1
 
@@ -96,7 +95,6 @@ describe Rack::Session::Redis do
     app.redis.dbsize.should.equal 1
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
-    res1["Set-Cookie"][session_match].should.equal session
     res1.body.should.equal '{"counter"=>2}'
     app.redis.dbsize.should.equal 1
 
@@ -108,7 +106,6 @@ describe Rack::Session::Redis do
     app.redis.dbsize.should.equal 1
 
     res3 = req.get("/", "HTTP_COOKIE" => new_cookie)
-    res3["Set-Cookie"][session_match].should.equal new_session
     res3.body.should.equal '{"counter"=>4}'
     app.redis.dbsize.should.equal 1
   end
@@ -125,7 +122,6 @@ describe Rack::Session::Redis do
     app.redis.dbsize.should.equal 1
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
-    res1["Set-Cookie"][session_match].should.equal session
     res1.body.should.equal '{"counter"=>2}'
     app.redis.dbsize.should.equal 1
 
@@ -135,7 +131,6 @@ describe Rack::Session::Redis do
     app.redis.dbsize.should.equal 1
 
     res3 = req.get("/", "HTTP_COOKIE" => cookie)
-    res3["Set-Cookie"][session_match].should.equal session
     res3.body.should.equal '{"counter"=>4}'
     app.redis.dbsize.should.equal 1
   end


### PR DESCRIPTION
Hi Harry,

There were some assertions wrongly being made that a Set-Cookie header would be returned for a request where a Cookie header had been provided. They were causing the tests to error. I removed them.

Also (at least for Rack 1.3.5 and 1.4), Rack::Session::Redis#destroy_session needed to be implemented to pass the tests (and presumably to exhibit correct behaviour in reality). I did a simple implementation that just passed through to #set_session.

Do these look right to you?

Thanks,
James
