### PR TITLE
Set an expiry for new sessions.

### DIFF
--- a/rack-session-redis.gemspec
+++ b/rack-session-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name     = "rack-session-redis"
-  s.version  = "0.0.3"
-  s.date     = "2011-03-05"
+  s.version  = "0.0.4"
+  s.date     = "2011-04-17"
   s.summary  = "redis session store for rack"
   s.email    = "harry@vangberg.name"
   s.homepage = "http://github.com/ichverstehe/rack-session-redis"


### PR DESCRIPTION
This way, you don't end up with 'persisent' sessions when you have an expiry set.
